### PR TITLE
change make target name to remote-dev to reflect its nature

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -14,7 +14,7 @@ dev:
 	env SLURM_TAG=slurm-20-11-4-1 OOD_TAG=1.8-1 OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose down -v || :
 	env SLURM_TAG=slurm-20-11-4-1 OOD_TAG=1.8-1 OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose up --build
 
-qa:
+remote-dev:
 	ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST) mkdir -p ./fasrc/dev/dashboard || :
 	SLURM_TAG=slurm-20-11-4-1 OOD_TAG=1.8-1 OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose run --no-deps --entrypoint="" ood su - ood bash -c "export PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$$PATH; cd /home/ood/ondemand/dev/dashboard; scl enable rh-ruby25 rh-nodejs10 'gem install --user-install bundler -v 1.17.3 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
 	rsync -avz --exclude-from='rsync-exclude.conf' ./application/ -e ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST):./fasrc/dev/dashboard
@@ -44,5 +44,5 @@ clean:
 
 	env SLURM_TAG=slurm-20-11-4-1 OOD_TAG=1.8-1 OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose down --rmi all
 
-clean_qa:
+clean-remote-dev:
 	ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST) rm -rfv ./fasrc/dev/dashboard || :

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -48,9 +48,9 @@ The following will launch a Sid Dashboard development environment with:
 
 - Run `make down`
 
-## Deploying to QA (your FASRC account)
+## Deploying to remote development (your FASRC account)
 
-- Run `make qa`. `make qa` builds all required OOD/Ruby libs locally and exports built artifacts to FASRC. This task will prompt you for your FASRC SSH credentials (password and pin) twice as it creates/validates the pre-requisite directory structure as setup in your home directory.
+- Run `make remote-dev`. `make remote-dev` builds all required OOD/Ruby libs locally and exports built artifacts to FASRC. This task will prompt you for your FASRC SSH credentials (password and pin) twice as it creates/validates the pre-requisite directory structure as setup in your home directory.
   
 - Once completed, visit:
 


### PR DESCRIPTION
Tiny change so that we will be doing 
make remote-dev
instead of 
make qa
which better reflects our nomenclature.

Addresses [this comment](https://github.com/hmdc/DevOpsProjects/issues/446#issuecomment-880944719) in [#446](https://github.com/hmdc/DevOpsProjects/issues/446)