### PR TITLE
568 display OOD and Sid version on dashboard footer

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -6,3 +6,4 @@
 
 /deployment/sid_passenger/files/application
 /application/config/rt_config.yml
+VERSION

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -2,7 +2,7 @@
 all::
 
 all:: dev
-.PHONY: dev
+.PHONY: dev remote-dev test release down up clean-remote-dev version
 
 OOD_UID := $(shell id -u)
 OOD_GID := $(shell id -g)
@@ -11,38 +11,41 @@ SLURM_TAG := slurm-20-11-4-1
 FASRC_USERNAME := $(if $(SSH_USERNAME),$(SSH_USERNAME),$(USER))
 FASRC_LOGIN_HOST := login.rc.fas.harvard.edu
 
-dev:
+NODE_VERSION=`cat ../.node-version`
+PWD = $(shell pwd)
 
+dev: version
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose down -v || :
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose up --build
 
-remote-dev:
+remote-dev: version
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose build
 	ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST) mkdir -p ./fasrc/dev/dashboard || :
 	SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose run --no-deps --entrypoint="" ood su - ood bash -c "export PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$$PATH; cd /home/ood/ondemand/dev/dashboard; scl enable rh-ruby27 rh-nodejs12 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
 	rsync -avz --exclude-from='rsync-exclude.conf' ./application/ -e ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST):./fasrc/dev/dashboard
 
 test:
-
 	SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose run --no-deps --entrypoint="" ood su - ood bash -c "export PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$$PATH; cd /home/ood/ondemand/dev/dashboard; scl enable rh-ruby27 rh-nodejs12 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake test'"
 
-release:
-
+release: next-version
 	SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose run --no-deps --entrypoint="" ood su - ood bash -c "export PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$$PATH; export RAILS_ENV=production; cd /home/ood/ondemand/dev/dashboard; scl enable rh-ruby27 rh-nodejs12 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
 	mkdir -p ./target
 	tar -czvf ./target/sid2-dashboard.tar.gz ./application
 
 down:
-
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose down -v || :
 
 up:
-
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose up --build
 
 clean:
-
 	env SLURM_TAG=$(SLURM_TAG) OOD_TAG=$(OOD_TAG) OOD_UID=$(OOD_UID) OOD_GID=$(OOD_GID) docker-compose down --rmi all
 
 clean-remote-dev:
 	ssh $(FASRC_USERNAME)@$(FASRC_LOGIN_HOST) rm -rfv ./fasrc/dev/dashboard || :
+
+version:
+	cp ../VERSION application/VERSION
+
+next-version:
+	docker run --rm -v $(PWD)/..:/usr/app -w /usr/app node:$(NODE_VERSION) /bin/bash -c "npm install && npm run version | tail -n 1 > dashboard/application/VERSION"

--- a/dashboard/application/app/assets/stylesheets/application.css.scss
+++ b/dashboard/application/app/assets/stylesheets/application.css.scss
@@ -213,6 +213,15 @@ pre.motd-monospaced {
   border-width: 0 0 3px;
   border-color: transparent;
 }
+
+.footer_version {
+  display: block;
+  min-height: 40px;
+  margin: 10px auto;
+  text-align: center;
+  white-space: nowrap;
+}
+
 // $fa-font-path: "fontawesome/fonts";
 @import "dashboard";
 @import "navbar";

--- a/dashboard/application/app/views/layouts/_footer.html.erb
+++ b/dashboard/application/app/views/layouts/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer>
   <div class="container-fluid">
     <div class="row">
-      <div class="col-md-2 col-sm-4">
+      <div class="col-lg-2 col-md-3 col-sm-4">
         <%= link_to "https://osc.github.io/Open-OnDemand/" do %>
           <%= image_tag(
                 "OpenOnDemand_powered_by_RGB.svg",
@@ -12,7 +12,7 @@
               ) %>
         <% end %>
       </div>
-      <div class="col-md-2 col-sm-4">
+      <div class="col-lg-2 col-md-3 col-sm-4">
         <%= link_to "https://vdi.rc.fas.harvard.edu/pun/sys/dashboard" do %>
           <%= image_tag(
                 "fasrc_logo.jpg",
@@ -23,7 +23,7 @@
               ) %>
         <% end %>
       </div>
-      <div class="col-md-2 col-sm-4">
+      <div class="col-lg-2 col-md-3 col-sm-4">
         <%= link_to "https://www.iq.harvard.edu/" do %>
           <%= image_tag(
                 "iqss_logo.png",
@@ -33,6 +33,12 @@
                 style: "margin-bottom: 20px; max-height: 40px;"
               ) %>
         <% end %>
+      </div>
+      <div class="col-lg-2 col-md-3 col-sm-4">
+        <span class="footer_version">OnDemand version: <%= Configuration.ood_version %></span>
+      </div>
+      <div class="col-lg-2 col-md-3 col-sm-4">
+        <span class="footer_version">Sid version: <%= Configuration.app_version %></span>
       </div>
     </div>
   </div><!-- /.container -->

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prepare": "husky install",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release": "release-it"
+    "release": "release-it",
+    "version": "release-it --release-version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added a make target to generate/use the version from `release-it` and copy it into the dashboard project.

This new target is executed before the current targets: `dev`, `remote-dev `and `release`
