### PR TITLE
feat(dashboard): gh #587 Upgrade Slurm to 21-08-2-1

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,6 +1,6 @@
 ARG SLURM_TAG
 
-FROM snkattck/slurm-docker-cluster:${SLURM_TAG}
+FROM hmdc/slurm-docker-cluster:${SLURM_TAG}
 
 ARG OOD_UID=3210
 ARG OOD_GID=3210

--- a/dashboard/Dockerfile.node
+++ b/dashboard/Dockerfile.node
@@ -1,6 +1,6 @@
 ARG SLURM_TAG
 
-FROM snkattck/slurm-docker-cluster:${SLURM_TAG}
+FROM hmdc/slurm-docker-cluster:${SLURM_TAG}
 
 ARG OOD_UID=3210
 ARG OOD_GID=3210

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -7,7 +7,7 @@ all:: dev
 OOD_UID := $(shell id -u)
 OOD_GID := $(shell id -g)
 OOD_TAG := 2.0.13-1.el7
-SLURM_TAG := slurm-20-11-4-1
+SLURM_TAG := slurm-21-08-2-1
 FASRC_USERNAME := $(if $(SSH_USERNAME),$(SSH_USERNAME),$(USER))
 FASRC_LOGIN_HOST := login.rc.fas.harvard.edu
 


### PR DESCRIPTION
Changes to upgrade the Slurm version to 21-08-2-1.

As well, updated the Docker configuration to use the new Docker image organization: `HMDC`
New images have already been built and uploaded to Docker Hub