### PR TITLE
feat(dashboard): gh #492 Added visual feedback when launchers are disabled

### DIFF
--- a/dashboard/application/app/assets/stylesheets/quick_launch.scss
+++ b/dashboard/application/app/assets/stylesheets/quick_launch.scss
@@ -79,10 +79,9 @@ $launcher-color-brown: #DA6027;
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
-
 }
 
-.launch-button-spinner {
+.launch-button-overlay {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -90,10 +89,18 @@ $launcher-color-brown: #DA6027;
   width: 100%;
   height: 100%;
   border-radius: 30px;
-  background-color: rgba(0, 0, 0, 0.5);
-  color: #fff;
   z-index: 1;
 }
+
+.launch-button-spinner {
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+}
+
+.launch-button-disabled {
+  background-color: rgba(255, 255, 255, 0.6);
+}
+
 .launch-button-spinner .spinner-border{
   width: 60px;
   height: 60px;

--- a/dashboard/application/app/views/quick_launch/_launch_button.html.erb
+++ b/dashboard/application/app/views/quick_launch/_launch_button.html.erb
@@ -5,9 +5,6 @@
        data-url="<%= ws_sessions_path %>"
        data-reload-url="<%= launchers_sessions_path(r: root_url, format: :js) %>"
        class="launch-button-container">
-  <div class="launch-button-spinner" style="display: none;">
-    <div class="spinner-border" role="status"></div>
-  </div>
   <div class="launch-button" style="border-color: <%= launcher_button[:color] || "#2D9BF0" %>;">
     <div class="panel-body panel-image">
       <img src="<%= asset_url launcher_button[:logo] %>" alt="Application logo" width="<%= launcher_button[:logoWidth] || 200 %>" class="center-block"  style="<%= launcher_button[:style] || '' %>"/>


### PR DESCRIPTION
If https://github.com/hmdc/sid2/pull/35 has not been merged when doing the review for these changes, there will be only one launcher in the development environment and testing will not be possible.

If that is the case, please use the `remote-dev` environment for the testing:
```
make clean-remote-dev
make remote-dev
```