### PR TITLE
fix(dashboard): gh #649 improve the cleaning power of make clean

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -54,7 +54,8 @@ up:
 	$(ENV) docker-compose up --build $(DETACHED_MODE)
 
 clean:
-	$(ENV) docker-compose down --rmi all
+	rm -rf application/.bundle application/VERSION application/log application/node_modules application/public/assets application/tmp application/vendor/bundle data/*
+	$(ENV) docker-compose down --rmi all --volumes
 
 clean-remote-dev clean-remote-fasse:
 	echo "For FASSE, you need to be connected to the VPN"

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -60,6 +60,12 @@ Docker images are used to create the local development environment. Information 
 
 - Run `make down`
 
+### Cleaning up
+
+- Run `make clean`
+
+To thoroughly purge your Docker environment, also run `docker volume prune; docker system prune -a` and restart Docker.
+
 ## Deploying to remote development (your FASRC account)
 
 - Run `make remote-dev`. `make remote-dev` builds all required OOD/Ruby libs locally and exports built artifacts to FASRC. This task will prompt you for your FASRC SSH credentials (password and pin) twice as it creates/validates the pre-requisite directory structure as setup in your home directory.


### PR DESCRIPTION
`make clean` now cleans up docker volumes and local build artifacts, with new and improved documentation.