### PR TITLE
fix(build): gh #813 updates to Sid OnDemand Docker image

### DIFF
--- a/dashboard/docker/Dockerfile.ondemand
+++ b/dashboard/docker/Dockerfile.ondemand
@@ -9,7 +9,7 @@ ARG OOD_TAG
 # Install Open On Demand, Singularity
 RUN yum install -y net-tools openssh-clients && \
     yum install -y https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm && \
-    yum install -y epel-release centos-release-scl lsof sudo httpd24-mod_ssl httpd24-mod_ldap && \
+    yum install -y epel-release centos-release-scl lsof sudo httpd24-mod_ssl httpd24-mod_ldap libyaml libyaml-devel && \
     yum -y update && \
     yum -y install --nogpgcheck ondemand-${OOD_TAG} && \
     mkdir -p /etc/ood/config/clusters.d && \

--- a/dashboard/launch-httpd
+++ b/dashboard/launch-httpd
@@ -8,14 +8,14 @@ if [ -f "/home/ood/ondemand/dev/dashboard/Gemfile" ]; then
 	echo "<<SID2>> Dashboard app detected, running bundle."
 	cd /home/ood/ondemand/dev/dashboard
 	PATH=/home/ood/bin:$PATH
-	env PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$PATH su ood bash -c "scl enable rh-ruby27 rh-nodejs12 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
+	env PATH=/home/ood/bin:/home/ood/ondemand/dev/dashboard/node_modules/.bin:$PATH su ood bash -c "scl enable rh-ruby27 rh-nodejs14 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
 fi
 
 if [ -f "/var/www/ood/apps/sys/sid/Gemfile" ]; then
 	echo "<<SID2>> SID app detected, running bundle."
 	cd /var/www/ood/apps/sys/sid
 	PATH=/home/ood/bin:$PATH
-	env PATH=/home/ood/bin:/var/www/ood/apps/sys/sid/node_modules/.bin:$PATH RAILS_ENV=production su ood bash -c "scl enable rh-ruby27 rh-nodejs12 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
+	env PATH=/home/ood/bin:/var/www/ood/apps/sys/sid/node_modules/.bin:$PATH RAILS_ENV=production su ood bash -c "scl enable rh-ruby27 rh-nodejs14 'gem install --user-install bundler -v 2.1.4 && bundle config --local path 'vendor/bundle' && bundle install && npm install yarn --save && bundle exec rake assets:precompile'"
 fi
 
 # Support changing environment variable options via docker run -e


### PR DESCRIPTION
# What this PR does / why we need it:
Updates to the Sid OnDemand Docker image to fix the build process for the latest OOD codebase.

It adds the package `libyaml` to the image as it is now needed by the Rails Gem `psych-5.0.1`.
This library is used in the latest update of the OnDemand Dashboard.

We need to update to `node14` too as the latest updates from CentOS installs this version of `node` 

PR for issue: https://github.com/hmdc/DevOpsProjects/issues/813

